### PR TITLE
change window focus after switching desktop #1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ debug = false
 panic = "abort"
 
 [dependencies]
-winvd = "0.0.46"
+winvd = "0.0.48"
 tray-item = "0.9.0"
 tokio = { version="1.34.0", features = ["full"] }
 winsafe = { version = "0.0.18", features = ["gui"] }
@@ -25,6 +25,7 @@ json = "0.12.4"
 open = "5.0.0"
 inputbot = "0.6.0"
 lazy_static = "1.4.0"
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_UI_Controls", "Win32_System_Console"] }
 
 [build-dependencies]
 embed-resource = "2.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,19 @@ mod keys;
 mod tray;
 mod version;
 
+use windows::Win32::System::Console::{
+    AllocConsole, FreeConsole
+};
+
 #[tokio::main]
 async fn main() {
+    // Establish this app as foreground capable application so it can use SetForegroundWindow
+    // Create gui console and immediately close it
+    unsafe {
+        let _ = AllocConsole();
+        let _ = FreeConsole();
+    }
+
 	tokio::spawn(keys::init());
 	tray::init();
 }


### PR DESCRIPTION
Hi,
thanks for the great tool. Here is my small contribution to improve it a bit.

This pull request addresses the issue #1.

It is still bit hacky solution because of the build in protections for windows focus switching, but overall seems to work ok. 

Among the many hacks that try to address the window focus issue, this is the only one witch seems to work consistently, at least on my extensive testing on one machine :) 

It is mainly inspired by https://github.com/amarmer/SetForegroundWindow, but because the spawning of new console each desktop switch causes the flicker of the created window it was unusable. However, I found out that this approach still works even if the console window is created only once, thus the resulting code.