### PR TITLE
Restore printf debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,8 +55,10 @@ dependencies = [
  "inputbot",
  "json",
  "lazy_static",
+ "log",
  "open",
  "regex",
+ "simple_logger",
  "tokio",
  "tray-item",
  "windows",
@@ -156,6 +158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +212,15 @@ name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "embed-resource"
@@ -359,6 +380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +516,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +637,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -730,6 +778,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_logger"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
+dependencies = [
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +836,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ open = "5.0.0"
 inputbot = "0.6.0"
 lazy_static = "1.4.0"
 windows = { version = "=0.58", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_UI_Controls", "Win32_System_Console"] }
+log = "0.4.27"
+simple_logger = { version = "5.0.0", features = ["stderr", "timestamps"] }
 
 [build-dependencies]
 embed-resource = "2.4.0"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,53 @@
+use std::{fs::OpenOptions, os::windows::io::AsRawHandle};
+
+use log::LevelFilter;
+use simple_logger::SimpleLogger;
+use windows::Win32::{
+	Foundation::HANDLE,
+	System::Console::{SetStdHandle, STD_ERROR_HANDLE},
+};
+
+pub fn init() {
+	set_stderr();
+	init_internal();
+
+	log::info!("Stderr redirected into stderr.log");
+}
+
+fn set_stderr() {
+	let file = OpenOptions::new()
+		.create(true)
+		.append(true)
+		.open("stderr.log")
+		.expect("Failed to open stderr.log");
+
+	let handle = HANDLE(file.as_raw_handle());
+	std::mem::forget(file);
+
+	unsafe {
+		// Redirect stderr
+		if SetStdHandle(STD_ERROR_HANDLE, handle).is_err() {
+			panic!("Failed to set stderr handle");
+		}
+	}
+}
+
+#[allow(dead_code)]
+#[cfg(debug_assertions)]
+fn init_internal() {
+	SimpleLogger::new()
+		.with_level(LevelFilter::Info)
+		.env()
+		.init()
+		.unwrap();
+}
+
+#[allow(dead_code)]
+#[cfg(not(debug_assertions))]
+fn init_internal() {
+	SimpleLogger::new()
+		.with_level(LevelFilter::Error)
+		.env()
+		.init()
+		.unwrap();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,22 @@
 mod config;
 mod gui;
 mod keys;
+mod logging;
 mod tray;
 mod version;
 
-use windows::Win32::System::Console::{
-    AllocConsole, FreeConsole
-};
+use windows::Win32::System::Console::{AllocConsole, FreeConsole};
 
 #[tokio::main]
 async fn main() {
-    // Establish this app as foreground capable application so it can use SetForegroundWindow
-    // Create gui console and immediately close it
-    unsafe {
-        let _ = AllocConsole();
-        let _ = FreeConsole();
-    }
+	// Establish this app as foreground capable application so it can use SetForegroundWindow
+	// Create gui console and immediately close it
+	unsafe {
+		let _ = AllocConsole();
+		let _ = FreeConsole();
+	}
 
+	logging::init();
 	tokio::spawn(keys::init());
 	tray::init();
 }


### PR DESCRIPTION
With PR #11 we lost the ability to printf debug binkybox.
This is quite frustrating, as debugging a keypress-reactive app is already painful.
For that reason, I’ve created this PR to restore the stderr stream (for panic! and eprintln!) and added basic logging infrastructure to support a more robust debugging experience.

A minor cosmetic issue with this solution is that the stderr.log file is created regardless of the log level.

Please not that my first commit restores crate versions, according to this [comment](https://github.com/nadimkobeissi/binkybox/pull/11#issuecomment-2812912599).